### PR TITLE
Accept SVG only when picking files

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 			<div class="stagecontent">
 				<span style="margin: 0 auto;"><input type="text" id="simulationtext" placeholder="your word" autocomplete="off" maxlength="14"></input><button onclick="updateText()">&gt;</button></span>
 				<p>- or -</p>
-				<input type="file" id="svgupload" name="svgupload" accept="image/svg" onchange="handleFiles(this.files)"><label for="svgupload" />choose a svg file</label>
+				<input type="file" id="svgupload" name="svgupload" accept="image/svg+xml" onchange="handleFiles(this.files)"><label for="svgupload" />choose a svg file</label>
 			</div>
 		</div>
 		<div class="stage orange" id="two">


### PR DESCRIPTION
The MIME type seems to be "image/svg+xml" instead of "image/svg". When
using the latter, recent versions of Firefox and Chromium don't
actually limit the filetype to SVGs.