### PR TITLE
export-svg: only export content not full view

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1131,7 +1131,7 @@ function enableShare(){
 function downloadSVG(){
 	crackPoint.remove();
 	paper.view.update();
-    var svg = project.exportSVG({ asString: true });    
+    var svg = project.exportSVG({ asString: true, bounds: 'content' });    
     var svgBlob = new Blob([svg], {type:"image/svg+xml;charset=utf-8"});
     var svgUrl = URL.createObjectURL(svgBlob);
     var downloadLink = document.createElement("a");


### PR DESCRIPTION
Resulting svg is not huge with much empty space anymore
Only contains the interesting part: the content